### PR TITLE
Changed model extension to save attachment after save

### DIFF
--- a/lib/nifty/attachments/model_extension.rb
+++ b/lib/nifty/attachments/model_extension.rb
@@ -4,7 +4,7 @@ module Nifty
 
       def self.included(base)
         base.extend ClassMethods
-        base.before_save do
+        base.after_save do
           if @pending_attachments
             @pending_attachments.each do |pa|
               old_attachments = self.nifty_attachments.where(:role => pa[:role]).pluck(:id)


### PR DESCRIPTION
It raise an error to try to save attachment to a unsaved model. And it
doesn’t make sense to save attachment before we are sure that the model
is saved correctly.
