### PR TITLE
Update model_extension.rb

### DIFF
--- a/lib/nifty/attachments/model_extension.rb
+++ b/lib/nifty/attachments/model_extension.rb
@@ -4,7 +4,7 @@ module Nifty
 
       def self.included(base)
         base.extend ClassMethods
-        base.before_save do
+        base.after_save do
           if @pending_attachments
             @pending_attachments.each do |pa|
               old_attachments = self.nifty_attachments.where(:role => pa[:role]).pluck(:id)


### PR DESCRIPTION
This will prevent the following error on model creation with attachments:
You cannot call create unless the parent is saved
